### PR TITLE
Performance Improvement

### DIFF
--- a/src/io/github/frenchy64/fully_satisfies.clj
+++ b/src/io/github/frenchy64/fully_satisfies.clj
@@ -29,21 +29,20 @@
             true)))
       (let [impls (:impls p)
             cimpl (or (get impls c)
-                      (when c
+                      (when (and c impls)
                         (let [;; copied from clojure.core
                               pref (fn
                                      ([] nil)
-                                     ([a] a) 
+                                     ([a] a)
                                      ([^Class a ^Class b]
                                       (if (.isAssignableFrom a b) b a)))]
-                          (or (get impls c)
-                              (first
-                                (sequence
-                                  (mapcat (fn [c]
-                                            (when (not (identical? Object c))
-                                              (when-some [impl (get impls c)]
-                                                [impl]))))
-                                  (super-chain c)))
+                          (or (first
+                               (sequence
+                                (mapcat (fn [c]
+                                          (when (not (identical? Object c))
+                                            (when-some [impl (get impls c)]
+                                              [impl]))))
+                                (super-chain c)))
                               (when-some [t (reduce pref
                                                     (filter #(get impls %)
                                                             (disj (supers c) Object)))]

--- a/src/io/github/frenchy64/fully_satisfies.clj
+++ b/src/io/github/frenchy64/fully_satisfies.clj
@@ -59,6 +59,6 @@
                           (get object-impls mmap-key)))
                     (-> p :method-map keys)))
           (if cimpl
-            (= (count cimpl)
-               (alength ims))
+            (.equals ^Integer (count cimpl)
+                     ^Integer (alength ims))
             false))))))


### PR DESCRIPTION
@frenchy64 I think the benchmark code is still not touching every single branch, but at least I was able to identify a redundant branch execution.

In my computer the benchmarks went from:

```clojure
Evaluation count : 4664160 in 60 samples of 77736 calls.
             Execution time mean : 12.956197 µs
    Execution time std-deviation : 100.882989 ns
   Execution time lower quantile : 12.787956 µs ( 2.5%)
   Execution time upper quantile : 13.159937 µs (97.5%)
                   Overhead used : 6.900840 ns
```

to
```clojure
Evaluation count : 73180260 in 60 samples of 1219671 calls.
             Execution time mean : 829.670232 ns
    Execution time std-deviation : 6.222736 ns
   Execution time lower quantile : 820.406518 ns ( 2.5%)
   Execution time upper quantile : 841.707715 ns (97.5%)
                   Overhead used : 6.900840 ns
```

Let's reclaim `ns` back :) can you confirm and update bench using ur data so we keep consistency? thanks